### PR TITLE
fix: remove dead ButtonWithRedirectToLocale component

### DIFF
--- a/app/button-with-redirect-to-locale.tsx
+++ b/app/button-with-redirect-to-locale.tsx
@@ -1,9 +1,0 @@
-const redirectTo = (locale: string) => {
-    
-}
-
-export default function ButtonWithRedirectToLocale({ locale }: { locale: string }) {
-    return (
-        <button className="mx-2 bg-blue-200 rounded" onClick={() => redirectTo('en')}>EN</button>
-    );
-}

--- a/app/language-switcher.tsx
+++ b/app/language-switcher.tsx
@@ -1,4 +1,3 @@
-import ButtonWithRedirectToLocale from "@/app/button-with-redirect-to-locale";
 import Link from "next/link";
 
 export default function LanguageSwitcher() {


### PR DESCRIPTION
Closes #49.

`redirectTo` had an empty body, the button hardcoded `"en"` (ignoring its `locale` prop), and the component was **imported but never rendered** — superseded by the links in `language-switcher`. Deleted the component and dropped the unused import.

lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)