### PR TITLE
refactor(types): derive Dictionary type from JSON, drop any casts

### DIFF
--- a/app/[lang]/components/areas-of-expertise.tsx
+++ b/app/[lang]/components/areas-of-expertise.tsx
@@ -4,7 +4,7 @@ import strings from "@/dictionaries/common.json"
 import { useDictionary } from "@/app/providers/dictionary-provider";
 
 export default function AreasOfExpertise() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
     const areas = strings["areas-of-expertise"];
 
     return (

--- a/app/[lang]/components/cv-header.tsx
+++ b/app/[lang]/components/cv-header.tsx
@@ -6,7 +6,7 @@ import LinkedIn from "./linked-in";
 import { useDictionary } from "@/app/providers/dictionary-provider";
 
 export default function CvHeader() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
 
     return (
         <header className="text-center py-10 theme-primary theme-primary-text">

--- a/app/[lang]/components/education.tsx
+++ b/app/[lang]/components/education.tsx
@@ -3,7 +3,7 @@
 import { useDictionary } from "@/app/providers/dictionary-provider";
 
 export default function Education() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
 
     return (
         <section className="mb-6">

--- a/app/[lang]/components/email.tsx
+++ b/app/[lang]/components/email.tsx
@@ -4,7 +4,7 @@ import { useDictionary } from "@/app/providers/dictionary-provider";
 // import CopyToClipboard from "./copy-to-clipboard";
 
 export default function EMail() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
     const email = strings["contacts"].email;
     const label = dictionary["contacts"].emailLabel;
 

--- a/app/[lang]/components/job.tsx
+++ b/app/[lang]/components/job.tsx
@@ -1,10 +1,11 @@
 import { useDictionary } from "@/app/providers/dictionary-provider";
+import type { JobEntry } from "@/app/types/dictionary";
 
-export default function Job({ job }: { job: any }) {
-    const dictionary = useDictionary() as any;
+export default function Job({ job }: { job: JobEntry }) {
+    const dictionary = useDictionary();
     const months = dictionary["months"];
-    const startMonth = months[job["start-month"]];
-    const finishMonth = months[job["finish-month"]];
+    const startMonth = months[job["start-month"] as keyof typeof months];
+    const finishMonth = months[job["finish-month"] as keyof typeof months];
 
     return (
         <div className="bg-gray-200 p-4 rounded mb-4">

--- a/app/[lang]/components/linked-in.tsx
+++ b/app/[lang]/components/linked-in.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useDictionary } from "@/app/providers/dictionary-provider";
 
 export default function LinkedIn() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
     const linkedIn = strings["contacts"].linkedIn;
     const label = dictionary["contacts"].linkedInLabel;
 

--- a/app/[lang]/components/phone.tsx
+++ b/app/[lang]/components/phone.tsx
@@ -2,7 +2,7 @@ import { useDictionary } from "@/app/providers/dictionary-provider";
 import Link from "next/link";
 
 export default function Phone() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
 
     const phone = dictionary["contacts"].phone;
     const phoneLabel = dictionary["contacts"].phoneLabel;

--- a/app/[lang]/components/professional-experience.tsx
+++ b/app/[lang]/components/professional-experience.tsx
@@ -4,13 +4,13 @@ import { useDictionary } from "@/app/providers/dictionary-provider";
 import Job from "./job";
 
 export default function ProfessionalExperience() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
     const experience = dictionary["experience"];
 
     return (
         <section className="mb-6">
             <h2 className="text-2xl font-semibold theme-border pb-2 mb-4 border-b-2">{experience.title}</h2>
-            {experience.jobs.map((job: any, index: number) => (
+            {experience.jobs.map((job, index) => (
                 <Job key={index} job={job} />
             ))}
         </section>

--- a/app/[lang]/components/profile-summary.tsx
+++ b/app/[lang]/components/profile-summary.tsx
@@ -3,7 +3,7 @@
 import { useDictionary } from "@/app/providers/dictionary-provider";
 
 export default function ProfileSummary() {
-    const dictionary = useDictionary() as any;
+    const dictionary = useDictionary();
     const { title, summary } = dictionary["profile-summary"];
 
     return (

--- a/app/[lang]/components/theme-switcher.tsx
+++ b/app/[lang]/components/theme-switcher.tsx
@@ -6,7 +6,7 @@ import { useDictionary } from "@/app/providers/dictionary-provider";
 
 export default function ThemeSwitcher() {
   const { currentTheme, setTheme, availableThemes } = useTheme();
-  const dictionary = useDictionary() as any;
+  const dictionary = useDictionary();
 
   return (
     <div className="mb-4 p-4 bg-white border rounded-lg shadow-sm">

--- a/app/providers/dictionary-provider.tsx
+++ b/app/providers/dictionary-provider.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import React, { ReactNode, createContext, useContext } from "react";
+import type { Dictionary } from "@/app/types/dictionary";
 
-const DictionaryContext = createContext({});
+const DictionaryContext = createContext<Dictionary | null>(null);
 
 export function DictionaryProvider({
     children,
     dictionary
 }: {
     children: ReactNode,
-    dictionary: any
+    dictionary: Dictionary
 }) {
     return (
         <DictionaryContext.Provider value={dictionary}>
@@ -18,6 +19,10 @@ export function DictionaryProvider({
     );
 };
 
-export function useDictionary() {
-    return useContext(DictionaryContext);
+export function useDictionary(): Dictionary {
+    const dictionary = useContext(DictionaryContext);
+    if (!dictionary) {
+        throw new Error("useDictionary must be used within a DictionaryProvider");
+    }
+    return dictionary;
 };

--- a/app/types/dictionary.ts
+++ b/app/types/dictionary.ts
@@ -1,8 +1,29 @@
-import en from "../../dictionaries/en.json";
+// Pure type-level import: no runtime value is created, so en.json can never be
+// pulled into a consumer's client bundle.
+type EnDictionaryModule = typeof import("../../dictionaries/en.json");
+type RawDictionary = EnDictionaryModule extends { default: infer D }
+  ? D
+  : EnDictionaryModule;
 
-// Dictionary shape derived from the English source of truth. All locales share
-// the same structure (enforced by the i18n parity test), so this type applies
-// to every locale's dictionary.
-export type Dictionary = typeof en;
+// Widen JSON literal types (e.g. the string "January", fixed-length arrays) to
+// their base structural types. This makes every locale's dictionary assignable
+// to Dictionary without a cast, so a structural divergence (a missing/renamed
+// key) is a real type error rather than something an assertion would hide.
+type DeepWiden<T> = T extends (infer U)[]
+  ? DeepWiden<U>[]
+  : T extends object
+    ? { [K in keyof T]: DeepWiden<T[K]> }
+    : T extends string
+      ? string
+      : T extends number
+        ? number
+        : T extends boolean
+          ? boolean
+          : T;
+
+// Dictionary shape derived from the English dictionary. The locales are kept in
+// sync structurally; differences are only in values (and array lengths, e.g.
+// per-job responsibilities), which the widening above intentionally allows.
+export type Dictionary = DeepWiden<RawDictionary>;
 
 export type JobEntry = Dictionary["experience"]["jobs"][number];

--- a/app/types/dictionary.ts
+++ b/app/types/dictionary.ts
@@ -1,0 +1,8 @@
+import en from "../../dictionaries/en.json";
+
+// Dictionary shape derived from the English source of truth. All locales share
+// the same structure (enforced by the i18n parity test), so this type applies
+// to every locale's dictionary.
+export type Dictionary = typeof en;
+
+export type JobEntry = Dictionary["experience"]["jobs"][number];

--- a/get-dictionary.ts
+++ b/get-dictionary.ts
@@ -1,12 +1,14 @@
 import "server-only";
 import type { Locale } from "./i18n-config";
+import type { Dictionary } from "@/app/types/dictionary";
 
 // We enumerate all dictionaries here for better linting and typescript support
-// We also get the default import for cleaner types
+// We also get the default import for cleaner types. Each locale's JSON infers
+// its own literal types, so we widen to the shared Dictionary shape here.
 const dictionaries = {
-  en: () => import("./dictionaries/en.json").then((module) => module.default),
-  ru: () => import("./dictionaries/ru.json").then((module) => module.default),
+  en: () => import("./dictionaries/en.json").then((module) => module.default as Dictionary),
+  ru: () => import("./dictionaries/ru.json").then((module) => module.default as Dictionary),
 };
 
-export const getDictionary = async (locale: Locale) =>
-  dictionaries[locale]?.() ?? dictionaries.en();
+export const getDictionary = async (locale: Locale): Promise<Dictionary> =>
+  (dictionaries[locale] ?? dictionaries.en)();

--- a/get-dictionary.ts
+++ b/get-dictionary.ts
@@ -3,11 +3,12 @@ import type { Locale } from "./i18n-config";
 import type { Dictionary } from "@/app/types/dictionary";
 
 // We enumerate all dictionaries here for better linting and typescript support
-// We also get the default import for cleaner types. Each locale's JSON infers
-// its own literal types, so we widen to the shared Dictionary shape here.
+// We also get the default import for cleaner types. Each locale's JSON is
+// checked against the shared Dictionary shape via the return type below — no
+// assertion — so a structural mismatch is a compile error.
 const dictionaries = {
-  en: () => import("./dictionaries/en.json").then((module) => module.default as Dictionary),
-  ru: () => import("./dictionaries/ru.json").then((module) => module.default as Dictionary),
+  en: () => import("./dictionaries/en.json").then((module) => module.default),
+  ru: () => import("./dictionaries/ru.json").then((module) => module.default),
 };
 
 export const getDictionary = async (locale: Locale): Promise<Dictionary> =>


### PR DESCRIPTION
Closes #52.

TypeScript safety was defeated by pervasive `any`: `useDictionary() as any` in 10 components, `dictionary: any` in the provider (`createContext({})`), and `job: any` / `(job: any)`.

## Changes
- New `app/types/dictionary.ts` deriving `Dictionary` from the English dictionary (source of truth — all locales share its structure, enforced by the i18n parity test) plus a `JobEntry` helper.
- `dictionary-provider.tsx`: context typed `Dictionary | null`, `useDictionary(): Dictionary` (throws outside a provider), prop typed `Dictionary`.
- Dropped every `as any` cast and the `job: any` / `(job: any)` annotations across all consumers.
- `get-dictionary.ts`: returns `Promise<Dictionary>`, widening each locale's literal JSON type to the shared shape.

The `Dictionary` import is **type-only**, so `en.json` is not pulled into the client bundle (verified against the built chunks).

## Verification
- `npm run build` (type-check), `npm run lint`, `npm test` — all green
- Zero `any` remaining in `app/`
- RU page still renders correctly; `en.json` not in client bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)