### PR TITLE
chore(config): bump tsconfig target es5 -> ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Closes #53.

## tsconfig target
`target: "es5"` is outdated for Next 16 / React 19 — it blocks modern syntax during type-checking. Bumped to **ES2017** (the current create-next-app / Next default).

(Note: Next transpiles via SWC against browserslist, so this mainly affects type-checking lib defaults and editor behavior, not the shipped bundle — but it removes a misleading, stale setting.)

## @types/react-dom — already fixed
The issue also flagged `@types/react-dom@^18` vs `react-dom@^19`. That's **already resolved** on master: `package.json` pins `@types/react-dom@^19.2.3` (matches `react-dom@^19.2.7`). No change needed.

## Verification
`npm run build` (type-check), `npm run lint`, `npm test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)