### PR TITLE
fix: stable list keys and fix "seamles" typo

### DIFF
--- a/app/[lang]/components/areas-of-expertise.tsx
+++ b/app/[lang]/components/areas-of-expertise.tsx
@@ -11,8 +11,8 @@ export default function AreasOfExpertise() {
         <section className="mt-6">
             <h2 className="text-2xl font-semibold theme-border pb-2 mb-4 border-b-2">{dictionary["areas-of-expertise"].title}</h2>
             <ul className="theme-secondary theme-secondary-text p-4 rounded">
-                {areas.map((expertise: string, index: number) => (
-                    <li key={index}>{expertise}</li>
+                {areas.map((expertise: string) => (
+                    <li key={expertise}>{expertise}</li>
                 ))}
             </ul>
         </section>

--- a/app/[lang]/components/job.tsx
+++ b/app/[lang]/components/job.tsx
@@ -14,8 +14,8 @@ export default function Job({ job }: { job: JobEntry }) {
             <p>{startMonth} {job["start-year"]} &mdash; {finishMonth} {job["finish-year"]}</p>
             <ul className="list-disc list-inside">
                 {
-                    job.responsibilities.map((responsibility: string, index: number) => (
-                        <li key={index}>{responsibility}</li>
+                    job.responsibilities.map((responsibility: string) => (
+                        <li key={responsibility}>{responsibility}</li>
                     ))
                 }
             </ul>

--- a/app/[lang]/components/professional-experience.tsx
+++ b/app/[lang]/components/professional-experience.tsx
@@ -10,8 +10,8 @@ export default function ProfessionalExperience() {
     return (
         <section className="mb-6">
             <h2 className="text-2xl font-semibold theme-border pb-2 mb-4 border-b-2">{experience.title}</h2>
-            {experience.jobs.map((job, index) => (
-                <Job key={index} job={job} />
+            {experience.jobs.map((job) => (
+                <Job key={`${job.company}-${job["start-year"]}`} job={job} />
             ))}
         </section>
     )

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -64,7 +64,7 @@
         "finish-month": "may",
         "responsibilities": [
           "Oversaw the creation of an all-encompassing web system that replaced Atlassian products including Bitbucket, Confluence, and Jira, improving productivity.",
-          "Conducted a thorough analysis to understand business requirements and developed extremely effective development procedures, leading to seamles workflows and quicker project completion.",
+          "Conducted a thorough analysis to understand business requirements and developed extremely effective development procedures, leading to seamless workflows and quicker project completion.",
           "Created a proof of concept for the main customer, delivering all initial project phases on time using Atlassian Confluence, Atlassian Jira, GitLab, GitLab CI/CD, GraphQL, PostgreSQL, Ruby, and Ruby on Rails."
         ]
       },


### PR DESCRIPTION
Closes #55.

## Stable keys (was `key={index}`)
- `professional-experience.tsx` → `` `${job.company}-${job["start-year"]}` ``
- `areas-of-expertise.tsx` → the expertise string
- `job.tsx` → the responsibility string

All are static, unique content, so they make good stable keys.

## Typo
- `en.json`: `"seamles"` → `"seamless"`

## Already resolved (no change)
- **Invalid Tailwind** (`bg-green`, `text-black-600`): `download-pdf.tsx` was deleted in #45.
- **`cuttingedge` / `C#\n.NET`**: the profile summary copy was cleaned when it moved into the dictionary in #50 (now `cutting-edge`, `C# .NET`).

## Verification
No `key={index}` remains; `en.json` valid; `npm run build`, `npm run lint`, `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)